### PR TITLE
Add comment explaining Vitest console redirection

### DIFF
--- a/test/RenovateRun.ts
+++ b/test/RenovateRun.ts
@@ -96,6 +96,7 @@ export class RenovateRun {
       .filter((line) => line.trim() !== "")) {
       try {
         this.logEntries.push(JSON.parse(output))
+        // Redirecting to `console` so vitest can intercept the output.
         console.log(output)
       } catch (cause) {
         this.parseErrors.push(`Failed to parse log line:\n${output}\n${cause}`)


### PR DESCRIPTION
### Motivation
- Clarify in-code why Renovate stdout is forwarded to `console` so Vitest can capture and surface logs for failing tests.

### Description
- Add a one-line code comment in `test/RenovateRun.ts` above the `console.log` call explaining that output is redirected to `console` for Vitest interception.

### Testing
- Ran `pnpm lint` which passed. 
- Ran `pnpm compile` which passed. 
- Ran `pnpm test` which failed due to an external host error (`ECONNRESET` when contacting `api.adoptium.net`) unrelated to the comment change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a367852e108832e8bbc7a05d31b420a)