### PR TITLE
Add comments for Vitest console output capture

### DIFF
--- a/test/RenovateRun.ts
+++ b/test/RenovateRun.ts
@@ -96,6 +96,7 @@ export class RenovateRun {
       .filter((line) => line.trim() !== "")) {
       try {
         this.logEntries.push(JSON.parse(output))
+        // Redirecting to `console` so vitest can intercept the output:
         console.log(output)
       } catch (cause) {
         this.parseErrors.push(`Failed to parse log line:\n${output}\n${cause}`)
@@ -107,6 +108,7 @@ export class RenovateRun {
     const output = chunk.toString()
     if (!RenovateRun.stderrCanBeIgnored(output)) {
       this.errorOutput += output
+      // Redirecting to `console` so vitest can intercept the output:
       console.error(output)
     }
   }


### PR DESCRIPTION
### Motivation
- Make the reason for forwarding Renovate stdout/stderr through `console` explicit so reviewers understand that Vitest captures those logs.

### Description
- Add inline comments in `test/RenovateRun.ts` immediately before the `console.log` and `console.error` calls explaining: "Redirecting to `console` so vitest can intercept the output." 

### Testing
- Ran `pnpm lint` and it passed. 
- Ran `pnpm compile` (`tsc`) and it passed. 
- Ran `pnpm check` (which runs the test suite) and it failed because a Renovate test hit an external host error (`ECONNRESET` contacting `api.adoptium.net`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3678488a94832e86a9a7d2f446867d)